### PR TITLE
add bug

### DIFF
--- a/server/routers/account.ts
+++ b/server/routers/account.ts
@@ -165,8 +165,7 @@ export const accountRouter = router({
       const accountTransactions = await db
         .select()
         .from(transactions)
-        .where(eq(transactions.accountId, input.accountId))
-        .orderBy(transactions.createdAt);
+        .where(eq(transactions.accountId, input.accountId));
 
       const enrichedTransactions = [];
       for (const transaction of accountTransactions) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `orderBy` clause from `getTransactions` in `account.ts`, altering transaction retrieval order.
> 
>   - **Behavior**:
>     - Removed `orderBy(transactions.createdAt)` from the `getTransactions` function in `account.ts`, affecting the order of retrieved transactions.
>   - **Misc**:
>     - No other changes were made to the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=burstcash%2Fsupport-engineer-interview&utm_source=github&utm_medium=referral)<sup> for ef43196fcaf0f68ac58cac0b30268d2c7a46d42b. You can [customize](https://app.ellipsis.dev/burstcash/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->